### PR TITLE
Check size without loading file

### DIFF
--- a/floss/floss.py
+++ b/floss/floss.py
@@ -150,7 +150,7 @@ class Floss(ServiceBase):
             stack_min_length = self.config.get("stack_min_length", 7)
         timeout = self.service_attributes.timeout - 50
 
-        if len(request.file_contents) > max_size:
+        if request.file_size > max_size:
             return
 
         stack_args = [FLOSS, f"-n {stack_min_length}", "--no-decoded-strings", file_path]


### PR DESCRIPTION
The `file_contents` reads the whole file to the memory. It will then stay there until GC cleans it up.

However, there is a property of ServiceRequest that just returns the file size, without needing to read the entire file.